### PR TITLE
Add support for vega tooltip handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ React class `Vega` and any output class from `createClassFromSpec` have these pr
 - **renderer**:String
 - **logLevel**:Number
 - **background**:String
+- **tooltip**:Function
 - **enableHover**:Boolean -- equivalent to calling `view.hover()`
 
 #### Data

--- a/src/Vega.jsx
+++ b/src/Vega.jsx
@@ -11,6 +11,7 @@ const propTypes = {
   logLevel: PropTypes.number,
   width: PropTypes.number,
   height: PropTypes.number,
+  tooltip: PropTypes.func,
   background: PropTypes.string,
   padding: PropTypes.object,
   renderer: PropTypes.string,
@@ -139,12 +140,13 @@ class Vega extends React.Component {
         this.view = view;
 
         [
+          'logLevel',
+          'renderer',
+          'tooltip',
+          'background',
           'width',
           'height',
-          'padding',
-          'renderer',
-          'logLevel',
-          'background',
+          'padding'
         ]
           .filter(field => isDefined(props[field]))
           .forEach((field) => { view[field](props[field]); });


### PR DESCRIPTION
Add support for the Vega view API's tooltip handler so users can add something like [vega-tooltip](https://github.com/vega/vega-tooltip) to their chart.  